### PR TITLE
manually count entries in partial data table

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ partial-data:
 > Or used inline: To you I say "{{< partial _hello.md >}}"
 > ```
 >
-> Hello, !
+> Hello, friend!
 >
-> Or used inline: To you I say “Hello, !”
+> Or used inline: To you I say “Hello, friend!”
 
 Alternatively, the second argument of the shortcode can point to a
 custom key in your YAML frontmatter, e.g.
@@ -74,7 +74,7 @@ my-data:
 > {{< partial _hello.md my-data.friends >}}
 > ```
 >
-> Hello, !
+> Hello, amigo!
 
 Another, possibly less convenient, option is to provide JSON in the
 shortcode data. Any key-value pair that starts with `{` or `[` will be

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -127,11 +127,7 @@ local function quarto_partial(args, kwargs, meta, raw_args, context)
     partial_data = copy(meta[partial_key])
   end
 
-  local nkeys = 0
-  for _ in pairs(partial_data) do
-    nkeys = nkeys + 1
-  end
-  if nkeys > 0 then
+  if next(partial_data) then
     local data_str = pandoc_stringify(partial_data)
 
     if type(data_str) == "string" then

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -127,7 +127,11 @@ local function quarto_partial(args, kwargs, meta, raw_args, context)
     partial_data = copy(meta[partial_key])
   end
 
-  if #partial_data > 0 then
+  local nkeys = 0
+  for _ in pairs(partial_data) do
+    nkeys = nkeys + 1
+  end
+  if nkeys > 0 then
     local data_str = pandoc_stringify(partial_data)
 
     if type(data_str) == "string" then


### PR DESCRIPTION
I believe this will fix #2. I don't know why, but it seems that having a table with named elements means that you can't use the `#` syntax to get the length (only for numeric indexes)