### PR TITLE
avoid "Blocks" recursion into pandoc_stringify

### DIFF
--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -36,7 +36,9 @@ local function pandoc_stringify(obj)
     return pandoc.utils.stringify(obj)
   end
 
-  if type(obj) == "table" then
+  -- descend into tables and stringify to prevent concatenation, but not if they are "Blocks",
+  -- which are paragraphs.
+  if type(obj) == "table" and pandoc.utils.type(obj) ~= "Blocks" then
     for k, v in pairs(obj) do
       obj[k] = pandoc_stringify(v)
     end


### PR DESCRIPTION
One of the things I found in #5 is that if you have a paragraph item (Blocks as opposed to Block), it is rendered as an object and looks... yeesh. This fixes it. 


Edit: example data with a paragraph YAML item. 

```yaml
ppl:
  hickory:
    name: "Doc"
    description: |
      Carpenter and Faulkner, two worshippers of an outlawed god, travel up the length of their deity’s great black river, searching for holy revelations amongst the reeds and the wetlands.
    links:
      - name: homepage
        url: https://example.com/home
      - name: awaypage
        url: https://example.com/away
```