### PR TITLE
allow for absolute paths to partials files

### DIFF
--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -61,16 +61,25 @@ end
 local function normalize_quarto_path(file)
   local prefix = ""
   local path = pandoc.utils.stringify(file)
-  if string.sub(path, 1, 1) == "/" then
+  local leader = string.sub(path, 1, 7)
+  if leader == "file://" then
+    -- MACHINE ROOT STARTS WITH file:///
+    path = string.sub(path, 8, -1)
+  elseif string.sub(leader, 1, 2) == "//" then
+    -- MACHINE ROOT STARTS WITH //
+    path = string.sub(path, 2, -1)
+  elseif string.sub(leader, 1, 1) == "/" then
+    -- QUARTO ROOT STARTS WITH /
     prefix = os.getenv("QUARTO_PROJECT_ROOT")
   end
   return prefix..path
 end
 
 local function render_partial(file, data, context)
-  local f = io.open(normalize_quarto_path(file), "rb")
+  local path = normalize_quarto_path(file)
+  local f = io.open(path, "rb")
   if f == nil then 
-    error("Error resolving partial - unable to open file " .. file)
+    error("Error resolving partial - unable to open file " .. path)
   end
   local template = f:read("*all")
 

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -58,16 +58,19 @@ function copy(obj, seen)
   return res
 end
 
-local function render_partial(file, data, context)
+local function normalize_quarto_path(file)
   local prefix = ""
   local path = pandoc.utils.stringify(file)
-  -- https://github.com/quarto-dev/quarto-cli/pull/8525
   if string.sub(path, 1, 1) == "/" then
     prefix = os.getenv("QUARTO_PROJECT_ROOT")
   end
-  local f = io.open(prefix..path, "rb")
+  return prefix..path
+end
+
+local function render_partial(file, data, context)
+  local f = io.open(normalize_quarto_path(file), "rb")
   if f == nil then 
-    error("Error resolving partial - unable to open file " .. path)
+    error("Error resolving partial - unable to open file " .. file)
   end
   local template = f:read("*all")
 

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -59,12 +59,18 @@ function copy(obj, seen)
 end
 
 local function render_partial(file, data, context)
-  -- from https://github.com/quarto-dev/quarto-cli/blob/7f211ce0d72a11cfea2094ea17620e0c97ce18ed/src/resources/filters/quarto-init/includes.lua#L52-L56
-  local f = io.open(pandoc.utils.stringify(file), "rb")
+  local prefix = ""
+  local path = pandoc.utils.stringify(file)
+  -- https://github.com/quarto-dev/quarto-cli/pull/8525
+  if string.sub(path, 1, 1) == "/" then
+    prefix = os.getenv("QUARTO_PROJECT_ROOT")
+  end
+  local f = io.open(prefix..path, "rb")
   if f == nil then 
-    fail("Error resolving " .. target .. "- unable to open file " .. file)
+    error("Error resolving partial - unable to open file " .. path)
   end
   local template = f:read("*all")
+
   f:close()
 
   local rendered = lustache:render(template, data)

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -59,8 +59,12 @@ function copy(obj, seen)
 end
 
 local function render_partial(file, data, context)
-  local f = io.open(file, "r")
-  local template = f:read("a")
+  -- from https://github.com/quarto-dev/quarto-cli/blob/7f211ce0d72a11cfea2094ea17620e0c97ce18ed/src/resources/filters/quarto-init/includes.lua#L52-L56
+  local f = io.open(pandoc.utils.stringify(file), "rb")
+  if f == nil then 
+    fail("Error resolving " .. target .. "- unable to open file " .. file)
+  end
+  local template = f:read("*all")
   f:close()
 
   local rendered = lustache:render(template, data)

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -73,7 +73,7 @@ end
 
 local function render_partial(file, data, context)
   local path = normalize_quarto_path(file)
-  local f = io.open(path, "rb")
+  local f = io.open(path, "r")
   if f == nil then 
     error("Error resolving partial - unable to open file " .. path)
   end

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -61,15 +61,11 @@ end
 local function normalize_quarto_path(file)
   local prefix = ""
   local path = pandoc.utils.stringify(file)
-  local leader = string.sub(path, 1, 7)
-  if leader == "file://" then
-    -- MACHINE ROOT STARTS WITH file:///
-    path = string.sub(path, 8, -1)
-  elseif string.sub(leader, 1, 2) == "//" then
-    -- MACHINE ROOT STARTS WITH //
-    path = string.sub(path, 2, -1)
-  elseif string.sub(leader, 1, 1) == "/" then
-    -- QUARTO ROOT STARTS WITH /
+  if path:sub(1, 7) == "file://" then
+    path = path:sub(8)
+  elseif path:sub(1, 2) == "//" then
+    path = path:sub(2)
+  elseif path:sub(1, 1) == "/" then
     prefix = os.getenv("QUARTO_PROJECT_ROOT") or ""
   end
   return prefix..path
@@ -92,7 +88,7 @@ local function render_partial(file, data, context)
     return pandoc.Str(rendered)
   end
 
-  if string.match(file, "%.qmd") then
+  if string.match(path, "%.qmd") then
     -- And `.qmd` through Quarto
     if context == "block" then
       return quarto.utils.string_to_blocks(rendered)
@@ -100,7 +96,7 @@ local function render_partial(file, data, context)
       return quarto.utils.string_to_inlines(rendered)
     end
 
-  elseif string.match(file, "%.md") or string.match(file, "%.txt") then
+  elseif string.match(path, "%.md") or string.match(path, "%.txt") then
     -- Render `.md` through Pandoc
 rendered = pandoc.read(rendered)
     if context == "inline" then
@@ -108,15 +104,15 @@ rendered = pandoc.read(rendered)
     end
     return rendered.blocks
 
-    
-  elseif string.match(file, "%.tex")  then
+
+  elseif string.match(path, "%.tex")  then
     -- Limit `.tex` to LaTeX documents
     if context == "inline" then
       return pandoc.RawBlock('tex', rendered)
     end
     return pandoc.RawBlock('tex', rendered)
-  
-  elseif string.match(file, "%.html") then
+
+  elseif string.match(path, "%.html") then
     -- And `.html` for HTML documents
     if context == "inline" then
       return pandoc.RawInline('html', rendered)

--- a/_extensions/partials/quarto-partials.lua
+++ b/_extensions/partials/quarto-partials.lua
@@ -70,7 +70,7 @@ local function normalize_quarto_path(file)
     path = string.sub(path, 2, -1)
   elseif string.sub(leader, 1, 1) == "/" then
     -- QUARTO ROOT STARTS WITH /
-    prefix = os.getenv("QUARTO_PROJECT_ROOT")
+    prefix = os.getenv("QUARTO_PROJECT_ROOT") or ""
   end
   return prefix..path
 end


### PR DESCRIPTION
This will fix #3 by prepending the `QUARTO_PROJECT_ROOT` env var.