### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/partials/_schema.yml
+++ b/_extensions/partials/_schema.yml
@@ -1,0 +1,15 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+shortcodes:
+  partial:
+    description: "Render a Mustache template partial with data from YAML metadata or keyword arguments."
+    arguments:
+      - name: file
+        type: string
+        required: true
+        description: "Path to the template file (.qmd, .md, .html, .tex, or .txt)."
+        completion:
+          type: file
+      - name: data-source
+        type: string
+        description: "Dot-separated key path into YAML metadata for template data (defaults to 'partial-data')."

--- a/_extensions/partials/_snippets.json
+++ b/_extensions/partials/_snippets.json
@@ -7,7 +7,7 @@
     "description": "Insert a partial with a template file."
   },
   "Partial with Data Source": {
-    "prefix": "partial-data",
+    "prefix": "data",
     "body": [
       "{{< partial ${1:template.qmd} ${2:data-key} ${3:var}=${4:value} >}}"
     ],

--- a/_extensions/partials/_snippets.json
+++ b/_extensions/partials/_snippets.json
@@ -1,0 +1,16 @@
+{
+  "Partial": {
+    "prefix": "partial",
+    "body": [
+      "{{< partial ${1:template.qmd} >}}"
+    ],
+    "description": "Insert a partial with a template file."
+  },
+  "Partial with Data Source": {
+    "prefix": "partial-data",
+    "body": [
+      "{{< partial ${1:template.qmd} ${2:data-key} ${3:var}=${4:value} >}}"
+    ],
+    "description": "Insert a partial with a data source key and template variables."
+  }
+}


### PR DESCRIPTION
## Summary

- Add `_schema.yml` declaring the `partial` shortcode with its `file` and `data-source` arguments.
- Add `_snippets.json` with two snippets: partial with file and partial with data source and variables.

## What is Quarto Wizard?

[Quarto Wizard](https://m.canouil.dev/quarto-wizard/dev/) is a VS Code extension that enhances the Quarto authoring experience with IDE tooling.
In its upcoming release, Quarto extensions will be able to contribute their own schema and snippets, which Quarto Wizard can use to provide autocompletion, validation, diagnostics, and snippet completion tailored to each extension.

Extensions opt in by shipping a `_schema.yml` file (declaring configurable options, shortcode parameters, element attributes, and CSS classes) and a `_snippets.json` file (VS Code-format snippets for common syntax patterns) alongside their `_extension.yml`.

- [Schema specification](https://m.canouil.dev/quarto-wizard/dev/reference/schema-specification.html)
- [Snippet specification](https://m.canouil.dev/quarto-wizard/dev/reference/snippet-specification.html)